### PR TITLE
Retrieve releases programmatically, and use Promises to simplify the code

### DIFF
--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -1,40 +1,185 @@
 <script type="text/javascript">
-	window.onload = function () {
-		var request = new XMLHttpRequest();
-		request.open("GET", "https://api.github.com/repos/cylc/cylc/milestones", true);
+"use strict";
 
-		request.onload = function () {
-			if (this.status >= 200 && this.status < 400) {
-				var data = JSON.parse(this.response);
+// --- Progress
 
-                var nr_data = data[1];
-                for (i = 0; i < data.length; i++ ) {
-                    if (data[i].title == "next-release") {
-                        nr_data = data[i];
-                    }
-                }
+/**
+ * Get the next release from a set of milestones. The next release is simply the milestone with
+ * a title 'next-release'.
+ *
+ * @param milestones: array of milestone objects
+ * @return the milestone titled 'next-release', or null if none found
+ */
+function getNextRelease(milestones) {
+    return milestones.find(function(milestone) {
+        return milestone.title === "next-release";
+    });
+}
+/**
+ * Populate progress elements in the DOM.
+ *
+ * @param openIssues: integer with the number of open issues
+ * @param closedIssues: integer with the number of closed issues
+ * @param title: the title of the next release
+ * @param link: URL link to the next release
+  */
+function populateProgress(openIssues, closedIssues, title, link) {
+    var workProgress = closedIssues * 100 / (openIssues + closedIssues);
 
-				var openIssues = nr_data.open_issues;
-				var closedIssues = nr_data.closed_issues;
-				var workProgress = closedIssues * 100 / (openIssues + closedIssues);
+    var milestoneVersion = document.getElementById("milestone-version");
+    milestoneVersion.innerHTML = title;
 
-				var milestoneVersion = document.getElementById("milestone-version");
-				var milestoneURL = document.getElementById("milestone-url");
-				milestoneVersion.innerHTML = nr_data.title;
-				milestoneURL.setAttribute('href', nr_data.html_url.replace('s/next%20release', '/'+nr_data.number));
+    var milestoneURL = document.getElementById("milestone-url");
+    milestoneURL.setAttribute('href', link);
 
-				var progressBarInner = document.getElementById("progress-bar-inner");
-				progressBarInner.style.width = workProgress + "%";
+    var progressBarInner = document.getElementById("progress-bar-inner");
+    progressBarInner.style.width = workProgress + "%";
 
-				var progress = document.getElementById("progress");
-				progress.innerHTML = Math.floor(workProgress) + "%";
+    var progress = document.getElementById("progress");
+    progress.innerHTML = Math.floor(workProgress) + "%";
 
-				var milestoneContainer = document.getElementById("milestone-container");
-				milestoneContainer.style.opacity = "1";
-				milestoneContainer.style.transition = ".7s ease-in";
-			}
-		};
+    var milestoneContainer = document.getElementById("milestone-container");
+    milestoneContainer.style.opacity = "1";
+    milestoneContainer.style.transition = ".7s ease-in";
+}
+/**
+ * Retrieve the progress of the project.
+ *
+ * @param url: GitHub API project milestones URL
+ * @return a Promise object that populates DOM elements, or returns the status text on error
+ */
+function retrieveProgress(url) {
+    return new Promise(function (resolve, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url);
 
-		request.send();
-	};
+        xhr.onload = function () {
+            var milestones = JSON.parse(this.response);
+            var nextRelease = getNextRelease(milestones);
+
+            if (nextRelease) {
+                var openIssues = nextRelease.open_issues;
+                var closedIssues = nextRelease.closed_issues;
+                var title = nextRelease.title;
+                var link = nextRelease.html_url.replace('s/next%20release', '/' + nextRelease.number);
+                populateProgress(openIssues, closedIssues, title, link);
+            }
+        };
+
+        xhr.onerror = reject(xhr.statusText);
+        xhr.send();
+    });
+}
+
+// --- Releases
+
+/**
+ * Truncate text at desired limit of max words. The text is split by
+ * white spaces. If the number of tokens produced is less than the
+ * given limit, we use the lowest value to truncate. Will append
+ * ellipsis if the text was truncated (i.e. words were discarded).
+ *
+ * @param text: text to be truncated
+ * @param maxWords: integer defining the maximum number of words to be returned
+ * @return truncated text, with ellipsis if words were discarded
+ */
+function truncate(text, maxWords) {
+    var tokens = text.trim().split(" ");
+    var limit = Math.min(tokens.length, maxWords) - 1;
+    var truncated = tokens.slice(0, limit);
+    if (limit < tokens.length) {
+        truncated.push("...");
+    }
+    return truncated.join(" ");
+}
+
+/**
+ * Create release HTML element to be added to the DOM.
+ *
+ * @param name: name of the release
+ * @param link: link for the GitHub release
+ * @param publishedAt: raw text date as returned from the API
+ * @param body: the description of the release
+ * @return a div HTML element with other elements within
+ */
+function createReleaseElement(name, link, publishedAt, body) {
+    var div = document.createElement("div");
+
+    var link = document.createElement("a");
+    link.setAttribute("href", link);
+    link.innerHTML = name;
+
+    var paragraph = document.createElement("p");
+    paragraph.appendChild(link);
+    var d = new Date(publishedAt),
+        month = '' + (d.getMonth() + 1),
+        day = '' + d.getDate(),
+        year = d.getFullYear();
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+    var formattedDate = [year, month, day].join('-');
+    paragraph.insertAdjacentHTML("beforeend", ", " + formattedDate);
+    div.appendChild(paragraph);
+
+    var small = document.createElement("small");
+    small.innerHTML = truncate(body, 15);
+    div.appendChild(small);
+
+    return div;
+}
+
+/**
+ * Retrieve the releases of the project.
+ *
+ * @param url: GitHub API project releases URL
+ * @param linkBaseUrl: Base URL to create links to releases
+ * @return a Promise object that populates and creates DOM elements, or returns the status text on error
+ */
+function retrieveReleases(url, linkBaseUrl) {
+    var releasesContainer = document.getElementById("repository-releases");
+    return new Promise(function(resolve, reject) {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", url);
+        xhr.onload = function() {
+            const releases = JSON.parse(this.response);
+            // we only want to iterate over 4 releases...
+            var min = Math.min(releases.length, 4);
+            releasesContainer.innerHTML = "";
+            for (var i = 0; i < min; ++i) {
+                var release = releases[i];
+                var name = release.name;
+                var publishedAt = release.published_at;
+                var body = release.body;
+                var link = linkBaseUrl + release.tag_name;
+                var releaseElement = createReleaseElement(name, link, publishedAt, body);
+                releasesContainer.appendChild(releaseElement);
+            }
+        };
+        xhr.onerror = reject(xhr.statusText);
+        xhr.send();
+    });
+}
+
+// --- window.onload
+
+/**
+ * Called when the browser loads the page. It will execute two promises asynchronously,
+ * one to retrieve the progress, and the other to retrieve the releases.
+ * If an error occurs, it will print the error to the browser console.
+ */
+window.onload = function () {
+    var milestonesUrl = "https://api.github.com/repos/cylc/cylc/milestones";
+    var releasesUrl = "https://api.github.com/repos/cylc/cylc/releases";
+    var releasesLinkBaseUrl = "https://github.com/cylc/cylc/releases/tag/";
+    Promise.all([
+        retrieveProgress(milestonesUrl),
+        retrieveReleases(releasesUrl, releasesLinkBaseUrl)
+    ])
+    .then(function() {
+        // all good here!
+    })
+    .catch(function(error) {
+        console.log(error);
+    });
+};
 </script>

--- a/_includes/repository.html
+++ b/_includes/repository.html
@@ -27,13 +27,6 @@
         <div id="progress">0%</div>
     </div>
     </p>
-    {% for release in site.github.releases limit: 4 %}
-    <p><a href="{{ site.github.releases_url }}/tag/{{ release.tag_name }}">
-        {{ release.name }}</a>,
-        {% include time.html date=release.published_at %}
-    </p>
-    <small>
-        {{ release.body | truncatewords: 15 }}
-    </small>
-    {% endfor %}
+
+    <div id="repository-releases">retrieving repository data...</div>
 </div>


### PR DESCRIPTION
This pull request addresses the recent issue about retrieving the releases from a repository different than the current one. Looks like the plugin we used before to retrieve metadata from GitHub, uses the configuration settings when running locally, but defaults to the current repository when GitHub Pages are built.

The releases were generated in Ruby, so when you loaded the page, you would see only one request to retrieve the milestones (used to create the progress bar). This is interesting, because it means that the releases are retrieved when the site is built & deployed.

@hjoliver my understanding is that having two separate repositories, this would be an issue later after we released Cylc. Because it means that if we released a new version of Cylc, we would have to publish the web site in order to retrieve the releases list.

With this new approach, we are always retrieving the list of releases. Which means that once a new release is pushed, the next time the user reloads the page, we will fetch the list of releases from GitHub and display them to the user.

A bit more of load on GitHub servers, but they should be caching + CDN, etc. :grin:  A quick preview of what it should look like is available here: https://kinow.github.io/ (I always use my own GitHub Pages site for testing).

Cheers
Bruno

ps: it was a good exercise to practice [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). They are fundamental when using Vue.js, and luckily we have `Future` and `Promise` in Java, which work similarly. Also learned about `insertAdjacentHTML` and that I can [test my JS code online](https://babeljs.io/repl/)... this change should be compatible with ES5 (most browsers).