### PR TITLE
Fix release link

### DIFF
--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -105,12 +105,12 @@ function truncate(text, maxWords) {
 function createReleaseElement(name, link, publishedAt, body) {
     var div = document.createElement("div");
 
-    var link = document.createElement("a");
-    link.setAttribute("href", link);
-    link.innerHTML = name;
+    var linkElement = document.createElement("a");
+    linkElement.setAttribute("href", link);
+    linkElement.innerHTML = name;
 
     var paragraph = document.createElement("p");
-    paragraph.appendChild(link);
+    paragraph.appendChild(linkElement);
     var d = new Date(publishedAt),
         month = '' + (d.getMonth() + 1),
         day = '' + d.getDate(),


### PR DESCRIPTION
Silly issue. In the function I was creating an HTML element programmatically, in a variable called `link`... only problem that the function also received a parameter `link`... so in the end I was replacing the variable and the link appeared blank (i.e. pointing to the same page). D'oh.

Fixed!