### PR TITLE
Ignore Jekyll's _site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+
+# Jekyll files
+_site/
+
+# File extensions
+
 *.dvi
 *.tex
 *.log


### PR DESCRIPTION
Hi!

Jekyll produces a folder `_site/` every time I run `jekyll serve` to test and develop the site. Would it be possible to add an entry in our `.gitignore`. Just in case I accidentally include it in a commit...

Cheers
Bruno