### PR TITLE
Fix latest release metadata

### DIFF
--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -129,6 +129,24 @@ function createReleaseElement(name, link, publishedAt, body) {
 }
 
 /**
+ * Populate HTML elements with information about the latest release.
+ *
+ * @param name: name of the release
+ * @param publishedAt: raw text date as returned from the API
+ */
+function populateLatestReleaseInformation(name, publishedAt) {
+
+    var latestReleaseName = document.getElementById("latest-release-name");
+    latestReleaseName.innerHTML = name;
+
+    var latestReleaseDateTime = document.getElementById("latest-release-pubdate-time");
+    latestReleaseDateTime.setAttribute("datetime", publishedAt);
+
+    var latestReleaseDateText = document.getElementById("latest-release-pubdate-text");
+    latestReleaseDateText.innerHTML = publishedAt;
+}
+
+/**
  * Retrieve the releases of the project.
  *
  * @param url: GitHub API project releases URL
@@ -153,6 +171,11 @@ function retrieveReleases(url, linkBaseUrl) {
                 var link = linkBaseUrl + release.tag_name;
                 var releaseElement = createReleaseElement(name, link, publishedAt, body);
                 releasesContainer.appendChild(releaseElement);
+
+                // we also display the latest release metadata
+                if (i == 0) {
+                    populateLatestReleaseInformation(name, publishedAt);
+                }
             }
         };
         xhr.onerror = reject(xhr.statusText);

--- a/_includes/repository.html
+++ b/_includes/repository.html
@@ -5,12 +5,10 @@
     <div style="margin-top:10px">
     <a href="http://www.metoffice.gov.uk"><img src="css/mo-logo-cut.jpg"></a>
     </div>
-    {% assign latest_release = site.github.releases | first %}
-    {% assign pubdate = latest_release.published_at %}
     <p>
-    <a class="button" href="{{ site.github.releases_url }}/latest">
-        Download {{latest_release.name}}<br />
-        <small>Released <time datetime="{{ pubdate }}">{{ pubdate }}</time></small>
+    <a class="button" href="https://github.com/cylc/cylc/releases/latest">
+        Download <span id="latest-release-name"></span><br />
+        <small>Released <time id="latest-release-pubdate-time" datetime=""><span id="latest-release-pubdate-text"></span></time></small>
     </a>
     </p>
     <p><a class="button" href="https://github.com/cylc/cylc">Clone cylc on GitHub</a></p>


### PR DESCRIPTION
Fix for #3, displays the latest release metadata dynamically with JavaScript instead of using Jekyll build-time information.