### PR TITLE
Remove jekyll-github-metadata as we are doing ajax calls now

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,6 @@
 # used by Github Pages.
 
 repository: cylc/cylc
-plugins:
- - "jekyll-github-metadata"
 
 # Jekyll treats directories beginning with underscores as having special meaning
 # and omits them from the build. This can be overridden by manually including


### PR DESCRIPTION
jekyll-github-metadata is broken when you use the latest version of Jekyll and sawyer, see https://github.com/lostisland/sawyer/issues/59

Which causes some errors when running `jekyll serve` or `jekyll build` to test the site before preparing a pull request.

As we now have Ajax calls in place, I believe we can remove this dependency.