### PR TITLE
Fix link to ESiWACE support page

### DIFF
--- a/support.md
+++ b/support.md
@@ -19,6 +19,6 @@ tracker](https://github.com/cylc/cylc/issues) bug reports and feature requests.
 
 If you are in Europe you may be eligible for cylc support from the [Centre of
 Excellence in Simulation of Weather and Climate in
-Europe](https://verc.enes.org/esiwace/services/sup_cylc).
+Europe](https://www.esiwace.eu/services-1/support/overview).
 
 


### PR DESCRIPTION
The current link is returning a 404 page in their website. Cylc is listed under their _Tools_ menu: https://portal.enes.org/models/software-tools/cylc

There, they have this link which I used to update our site. That page, however, asks for credentials. Not sure whether best to use this one, or maybe link to their Tools page?