### PR TITLE
Update footer links (Google groups to Discourse)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,8 +4,8 @@
                     <div class="column" style="width:25%">
                         <h4>Support</h4>
                         <ul>
-                            <li><a href="https://groups.google.com/d/forum/cylc">Forum</a></li>
-                            <li><a href="https://github.com/cylc/cylc/issues">Issues</a></li>
+                            <li><a href="https://cylc.discourse.group/">Forum</a></li>
+                            <li><a href="https://github.com/cylc/cylc-flow/issues">Issues</a></li>
                         </ul>
                     </div>  <!--column-->
                     <div class="column" style="width:25%">
@@ -18,8 +18,8 @@
                     <div class="column" style="width:25%">
                         <h4>Development</h4>
                         <ul>
-                            <li><a href="https://github.com/cylc/cylc">Repository</a></li>
-                            <li> <a href="https://github.com/cylc/cylc/blob/master/CHANGES.md">Changes</a>
+                            <li><a href="https://github.com/cylc/cylc-flow">Repository</a></li>
+                            <li> <a href="https://github.com/cylc/cylc-flow/blob/master/CHANGES.md">Changes</a>
  
                         </ul>
                     </div>  <!--column-->


### PR DESCRIPTION
Update to some footer links:

*  new forum;
* ``cylc/cylc`` to ``cylc/cylc-flow`` for GitHub links, while I was updating the above, as this is the desired endpoint despite the former redirecting to the latter anyway.