### PR TITLE
Log to browser console GitHub API errors

### DIFF
--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -13,7 +13,18 @@
 function getNextRelease(milestones) {
     // Sort the milestones by due date
     if (!milestones) {
+        console.error("Invalid milestones value")
         return null
+    }
+    if (milestones instanceof Object) {
+        // GitHub API returns {documentation_url: "", message: ""} messages for rate limiting
+        // see https://developer.github.com/v3/#rate-limiting
+        // and https://github.com/cylc/cylc.github.io/issues/15
+        if (Object.prototype.hasOwnProperty.call(milestones, 'message')) {
+            console.error(milestones.message)
+        } else {
+            console.error("Invalid milestones value: " )
+        }
     }
     milestones.sort((a, b) => a.due_on < b.due_on ? -1 : a.due_on > b.due_on ? 1 : 0)
     return milestones[0]


### PR DESCRIPTION
Tricky to test, as you need the GitHub API to return an error message, or find a way to simulate it.

"Luckily", @hjoliver, myself and anybody else within NIWA are getting this error now for the GitHub API :grimacing: so I could write this piece of code to log to the console if it gets an `Object` instead of an `Array`.

