### PR TITLE
Untabify central files for consistency & HTML style

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<title>cylc - {{ page.title }}</title>
-		<link rel="stylesheet" type="text/css" href="css/main.css">
-	</head>
-	<body>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>cylc - {{ page.title }}</title>
+        <link rel="stylesheet" type="text/css" href="css/main.css">
+    </head>
+    <body>
         {% include header.html %}
-		<div id="wrapper">
-			<div class="page">
-				{{ content }}
+        <div id="wrapper">
+            <div class="page">
+                {{ content }}
             </div> <!--page-->
         </div> <!--wrapper-->
         {% include footer.html %}
-	</body>
+    </body>
 </html>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<title>cylc - {{ page.title }}</title>
-		<link rel="stylesheet" type="text/css" href="css/main.css">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>cylc - {{ page.title }}</title>
+        <link rel="stylesheet" type="text/css" href="css/main.css">
         {% include progress.html %}
-	</head>
-	<body>
+    </head>
+    <body>
 {% include header.html %}
         <div id="wrapper">
             <div class="page">
@@ -17,5 +17,5 @@
             </div>  <!--page-->
         </div>  <!--wrapper-->
 {% include footer.html %}
-	</body>
+    </body>
 </html>

--- a/documentation.md
+++ b/documentation.md
@@ -90,42 +90,42 @@ read the User Guide!
     $ vim ~/suites/test/suite.rc
 
     # suite.rc:
-	[meta]
-	  title = Test Suite One
+    [meta]
+      title = Test Suite One
 
-	[cylc]
-	  cycle point format = %Y
+    [cylc]
+      cycle point format = %Y
 
-	[scheduling]
-	  initial cycle point = 2021
-	  final cycle point = 2023
-	  [[dependencies]]
-	    [[[R1]]]  # Initial cycle point.
-	      graph = prep => model
-	    [[[R//P1Y]]]  # Yearly cycling.
-	      graph = model[-P1Y] => model => post
-	    [[[R1/P0Y]]]  # Final cycle point.
-	      graph = post => stop
+    [scheduling]
+      initial cycle point = 2021
+      final cycle point = 2023
+      [[dependencies]]
+        [[[R1]]]  # Initial cycle point.
+          graph = prep => model
+        [[[R//P1Y]]]  # Yearly cycling.
+          graph = model[-P1Y] => model => post
+        [[[R1/P0Y]]]  # Final cycle point.
+          graph = post => stop
 
-	[runtime]
-	  [[root]]  # Inherited by all tasks.
-	    script = sleep 10
-	  [[model]]
-	    script = echo "my FOOD is $FOOD"; sleep 10
-	    [[[environment]]]
-	      FOOD = icecream
-	  [[prep]]
-	    # ...
-	  # ...
+    [runtime]
+      [[root]]  # Inherited by all tasks.
+        script = sleep 10
+      [[model]]
+        script = echo "my FOOD is $FOOD"; sleep 10
+        [[[environment]]]
+          FOOD = icecream
+      [[prep]]
+        # ...
+      # ...
 
-	[visualization]
-	  use node color for edges = True
-	  [[node attributes]]
-	    root = "style=filled", "fontcolor=white"
-	    prep =  "color=#00a778"
-	    stop =  "color=#bf9c00"
-	    model = "color=#0074cd"
-	    post =  "color=#af3936"
+    [visualization]
+      use node color for edges = True
+      [[node attributes]]
+        root = "style=filled", "fontcolor=white"
+        prep =  "color=#00a778"
+        stop =  "color=#bf9c00"
+        model = "color=#0074cd"
+        post =  "color=#af3936"
 
 ### Register
 


### PR DESCRIPTION
Convert tabs to four whitespace characters in a small number of files in this repository which were indented with tab characters, doing so:

* for consistency: spaces are otherwise used throughout files, in line with our general Cylc team standard of using spaces (as enforced for our Python code by PEP8, & for our JS [most ESLint variations](https://eslint.org/docs/rules/indent));
* to obey HTML(5) code conventions state only spaces should be used (e.g. [Google](https://google.github.io/styleguide/htmlcssguide.html#Indentation), [W3](https://www.w3schools.com/html/html5_syntax.asp)).

Note:
* I am only suggesting here replacing tabs on tabbed files that are likely to be touched in future i.e. the any HTML, markdown, CSS etc. that generates, templates or styles the main site content; the two talk directories (``BoM-Feb-2017`` & ``cylc-keynote-lisbon-Sept2016``, seem to be largely written with tabs (see the output of a top-level ``git grep $'\t'``), but as presentation materials they can be considered static, so there is no need to convert.
* Looking at the code changes on this PR, ``git`` does not seem to be good at interpreting the tab conversion. FYI, the only changes I made were to open these files & run [``M-x untabify`` in ``emacs``](https://www.gnu.org/software/emacs/manual/html_node/emacs/Just-Spaces.html). If you check out this branch, the files should actually appear exactly the same, notably in terms of indent level.

Trivial, so one reviewer sufficient (to sanity check)?