### PR TITLE
Add .jekyll-cache folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Jekyll files
 _site/
+.jekyll-cache/
 
 # File extensions
 
@@ -17,3 +18,4 @@ _site/
 *.xref
 *.sty
 *.cfg
+


### PR DESCRIPTION
This folder is created whenever the site is built & served locally via `jekyll serve --watch`.