### PR TITLE
Now include all files in github/gitignore for Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 
 # Jekyll files
 _site/
+.sass-cache/
 .jekyll-cache/
+.jekyll-metadata
 
 # File extensions
 


### PR DESCRIPTION
Got another Jekyll file in my `git status`, then added all entries from GitHub's [.gitignore](https://github.com/github/gitignore/blob/master/Jekyll.gitignore) template for Jekyll.

No more PR's for Jekyll files in gitignore after this, hopefully.

Thanks
Bruno