### PR TITLE
Remove reference to deleted 'cylc doc' command

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -15,8 +15,7 @@ title: documentation
 
 ### The Cylc User Guide
 
-If you have access to cylc already, type `cylc doc` or use the GUI "Help" menu
-to view the User Guide.  Otherwise, an online copy is available here:
+Online copies of the documentation are available here:
 
 * [Multi-Page version](doc/built-sphinx/index.html) (with word search box)
 * [Single-Page version](doc/built-sphinx-single/index.html) - (search with browser Ctrl-F)


### PR DESCRIPTION
After cylc/cylc-flow#3354. I have just noticed a reference to the deleted command on the website, so we should remove it in anticipation of Cylc 8.0.0. (The other option being to open an Issue to remove it nearer the time of release, but I don't think users will be missing out on anything by not being informed of the command as at present?)