### PR TITLE
cylc-7 and cylc-8 download buttons

### DIFF
--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -145,18 +145,23 @@ function createReleaseElement(name, link, publishedAt, body) {
 /**
  * Populate HTML elements with information about the latest release.
  *
+ * @param cylcx: 'cylc8' or 'cylc7'
  * @param name: name of the release
+ * @param link: URL of the release
  * @param publishedAt: raw text date as returned from the API
  */
-function populateLatestReleaseInformation(name, publishedAt) {
+function populateLatestReleaseInformation(cylcx, name, link, publishedAt) {
 
-    var latestReleaseName = document.getElementById("latest-release-name");
+    var latestReleaseName = document.getElementById(cylcx + "-latest-release-name");
     latestReleaseName.innerHTML = name;
 
-    var latestReleaseDateTime = document.getElementById("latest-release-pubdate-time");
+    var latestReleaseURL = document.getElementById(cylcx + "-button");
+    latestReleaseURL.href = link;
+
+    var latestReleaseDateTime = document.getElementById(cylcx + "-latest-release-pubdate-time");
     latestReleaseDateTime.setAttribute("datetime", publishedAt);
 
-    var latestReleaseDateText = document.getElementById("latest-release-pubdate-text");
+    var latestReleaseDateText = document.getElementById(cylcx + "-latest-release-pubdate-text");
     latestReleaseDateText.innerHTML = publishedAt;
 }
 
@@ -168,29 +173,32 @@ function populateLatestReleaseInformation(name, publishedAt) {
  * @return a Promise object that populates and creates DOM elements, or returns the status text on error
  */
 function retrieveReleases(url, linkBaseUrl) {
-    var releasesContainer = document.getElementById("repository-releases");
     return new Promise(function(resolve, reject) {
         const xhr = new XMLHttpRequest();
         xhr.open("GET", url);
         xhr.onload = function() {
             const releases = JSON.parse(this.response);
-            // we only want to iterate over 4 releases...
-            var min = Math.min(releases.length, 2);
-            releasesContainer.innerHTML = "";
+            var min = Math.min(releases.length, 15);
+            var foundCylc8Latest = false;
+            var foundCylc7Latest = false;
             for (var i = 0; i < min; ++i) {
                 var release = releases[i];
                 var name = release.name;
                 var publishedAt = release.published_at;
                 var body = release.body;
                 var link = linkBaseUrl + release.tag_name;
-                var releaseElement = createReleaseElement(name, link, publishedAt, body);
-                releasesContainer.appendChild(releaseElement);
-
-                // we also display the latest release metadata
-                if (i == 0) {
-                    populateLatestReleaseInformation(name, publishedAt);
-                }
-            }
+                // display latest release metadata
+                if (name.startsWith("cylc-7.8")) {
+                    populateLatestReleaseInformation("cylc7", name, link, publishedAt);
+                    foundCylc7Latest = true;
+                } else if (name.startsWith("cylc-flow-8")) {
+                    populateLatestReleaseInformation("cylc8", name, link, publishedAt);
+                    foundCylc8Latest = true;
+                };
+                if (foundCylc7Latest === true && foundCylc8Latest === true) {
+                    break;
+                };
+            };
         };
         xhr.onerror = reject(xhr.statusText);
         xhr.send();

--- a/_includes/progress.html
+++ b/_includes/progress.html
@@ -108,41 +108,6 @@ function truncate(text, maxWords) {
 }
 
 /**
- * Create release HTML element to be added to the DOM.
- *
- * @param name: name of the release
- * @param link: link for the GitHub release
- * @param publishedAt: raw text date as returned from the API
- * @param body: the description of the release
- * @return a div HTML element with other elements within
- */
-function createReleaseElement(name, link, publishedAt, body) {
-    var div = document.createElement("div");
-
-    var linkElement = document.createElement("a");
-    linkElement.setAttribute("href", link);
-    linkElement.innerHTML = name;
-
-    var paragraph = document.createElement("p");
-    paragraph.appendChild(linkElement);
-    var d = new Date(publishedAt),
-        month = '' + (d.getMonth() + 1),
-        day = '' + d.getDate(),
-        year = d.getFullYear();
-    if (month.length < 2) month = '0' + month;
-    if (day.length < 2) day = '0' + day;
-    var formattedDate = [year, month, day].join('-');
-    paragraph.insertAdjacentHTML("beforeend", ", " + formattedDate);
-    div.appendChild(paragraph);
-
-    var small = document.createElement("small");
-    small.innerHTML = truncate(body, 15);
-    div.appendChild(small);
-
-    return div;
-}
-
-/**
  * Populate HTML elements with information about the latest release.
  *
  * @param cylcx: 'cylc8' or 'cylc7'

--- a/_includes/repository.html
+++ b/_includes/repository.html
@@ -4,14 +4,14 @@
         <span id="cylc7-latest-release-name">(retrieving data...)</span>
         <small>PRODUCTION<br /><time id="cylc7-latest-release-pubdate-time" datetime=""><span id="cylc7-latest-release-pubdate-text"></span></time></small>
     </a>
-		</p>
-		<p>
+  </p>
+  <p>
     <a class="button" id="cylc8-button" href="https://github.com/cylc/cylc-flow/releases">
         <span id="cylc8-latest-release-name">(retrieving data...)</span>
         <small>PREVIEW<br /><time id="cylc8-latest-release-pubdate-time" datetime="">
-								<span id="cylc8-latest-release-pubdate-text"></span></time></small>
+           <span id="cylc8-latest-release-pubdate-text"></span></time></small>
     </a>
-		</p>
+   </p>
     <div id="milestone-container" style="padding-bottom:20px; margin-bottom:40px">
         <div style="float:left; width:75%">
             <a id="milestone-url" href="{{site.github.repository_url}}/milestones">

--- a/_includes/repository.html
+++ b/_includes/repository.html
@@ -1,9 +1,17 @@
 <div id="repository">
-    <a class="button" href="https://github.com/cylc/cylc/releases/latest">
-        Download <span id="latest-release-name"></span><br />
-        <small>Released <time id="latest-release-pubdate-time" datetime=""><span id="latest-release-pubdate-text"></span></time></small>
+   <p>
+    <a class="button" id="cylc7-button" href="https://github.com/cylc/cylc-flow/releases">
+        <span id="cylc7-latest-release-name">(retrieving data...)</span>
+        <small>PRODUCTION<br /><time id="cylc7-latest-release-pubdate-time" datetime=""><span id="cylc7-latest-release-pubdate-text"></span></time></small>
     </a>
-    <p><a class="button" href="https://github.com/cylc/cylc">Clone cylc on GitHub</a></p>
+		</p>
+		<p>
+    <a class="button" id="cylc8-button" href="https://github.com/cylc/cylc-flow/releases">
+        <span id="cylc8-latest-release-name">(retrieving data...)</span>
+        <small>PREVIEW<br /><time id="cylc8-latest-release-pubdate-time" datetime="">
+								<span id="cylc8-latest-release-pubdate-text"></span></time></small>
+    </a>
+		</p>
     <div id="milestone-container" style="padding-bottom:20px; margin-bottom:40px">
         <div style="float:left; width:75%">
             <a id="milestone-url" href="{{site.github.repository_url}}/milestones">
@@ -15,7 +23,6 @@
         </div>
         <div id="progress">0%</div>
     </div>
-    <div id="repository-releases">retrieving repository data...</div>
     <div style="margin-top:10px">
        <a href="users.html"><img src="css/logos.png" alt="Known cylc users."></a>
     </div>

--- a/index.md
+++ b/index.md
@@ -5,13 +5,11 @@ title: a workflow engine
 
 ## Cylc ("silk") is a workflow engine for cycling systems
 
-Use cases for cycling include:
+Use cases for include:
 
- * Running successive cycles of an environmental forecasting system (where in
-   real time operation new forecasts are initiated at regular intervals; but in
-   catch-up or historical mode dependencies may allow concurrent cycles).
+ * Running successive cycles of an environmental forecasting system.
 
- * Splitting long model runs into a sequence of smaller runs, with associated
+ * Splitting long model integrations into many smaller chunks, with associated
    processing tasks for each chunk.
 
  * Running successive steps in some multi-task iterative process, such as for
@@ -28,31 +26,29 @@ and
 [others](https://github.com/cylc/cylc/blob/master/CONTRIBUTING.md#code-contributors).
 It is [available under the GPL v3 license](./license.html).
 
-{% include feature.html content="Workflows are defined in a human-readable
-config file format - so you can use software development power tools for suite
-development." %}
+{% include feature.html content="Workflows are configured in a human-readable
+text format (with programmatic templating)- so you can use software development
+power tools for suite development." %}
 
-{% include feature.html content="Configure scheduling with an efficient graph
-description notation, and task runtime properties in an efficient inheritance
-hierarchy (to factor out all commonality)." %}
+{% include feature.html content="Scheduling is configured with an efficient
+cycling graph notation, and task runtime properties with an efficient
+inheritance hierarchy." %}
 
 {% include feature.html content="Cylc respects inter-cycle dependence and
-dynamically generates new workflow without being constrained by a global cycle
-loop, so that cycles can interleave naturally for much improved scheduling
-during catch-up from delays." %}
+is not constrained by a traditional global cycle loop, so cycles can interleave
+naturally for fast scheduling after delays, and for "off the clock" operation."
+%}
 
 {% include feature.html content="Cylc has low admin overhead and a small
-security footprint, because - as a distributed system - there is no central
-server process to manage workflows for all users." %}
+security footprint, because there is no central server process to manage
+workflows for all users." %}
 
 {% include feature.html content="Plus <a href='features.html'>many other
 features</a> to support both clock-triggered real time and free-flow
-metascheduling in research and operational environments." %}
+scheduling in research and operational environments." %}
+
+If you use Cylc to automate your workflows, [please cite Cylc in your
+publications](documentation.html#publications-citations-and-references).
 
 [Let us know](mailto:hilary.oliver@niwa.co.nz) if your organization
 should be listed on this site with [Cylc Users](./users.html).
-
-If you use Cylc to automate your workflows, [please cite Cylc in resulting
-publications](documentation.html#publications-citations-and-references).
-
-See also [publications and citations](./documentation.html#publications-and-citations)

--- a/index.md
+++ b/index.md
@@ -49,9 +49,10 @@ server process to manage workflows for all users." %}
 features</a> to support both clock-triggered real time and free-flow
 metascheduling in research and operational environments." %}
 
-Please [let us know](mailto:hilary.oliver@niwa.co.nz) if your organization
-should be included in the **[list of Cylc users](./users.html)**.
+[Let us know](mailto:hilary.oliver@niwa.co.nz) if your organization
+should be listed on this site with [Cylc Users](./users.html).
 
-Here's the DOI to use when citing Cylc: [![DOI](https://zenodo.org/badge/1836229.svg)](https://zenodo.org/badge/latestdoi/1836229)
+If you use Cylc to automate your workflows, [please cite Cylc in resulting
+publications](documentation.html#publications-citations-and-references).
 
 See also [publications and citations](./documentation.html#publications-and-citations)

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: a workflow engine
 
 ## Cylc ("silk") is a workflow engine for cycling systems
 
-Use cases for include:
+Use cases include:
 
  * Running successive cycles of an environmental forecasting system.
 
@@ -20,15 +20,15 @@ Use cases for include:
 
 Cylc was originally developed for operational environmental forecasting at
 [NIWA](http://www.niwa.co.nz) by [Dr Hilary
-Oliver](mailto:hilary.oliver@niwa.co.nz). It is now an Open
-Source collaboration involving NIWA, [Met Office](http://www.metoffice.gov.uk),
-and
+Oliver](mailto:hilary.oliver@niwa.co.nz) - however it is not specialized to
+forecasting in any way. It is now an Open Source collaboration involving NIWA,
+[Met Office](http://www.metoffice.gov.uk), and
 [others](https://github.com/cylc/cylc/blob/master/CONTRIBUTING.md#code-contributors).
 It is [available under the GPL v3 license](./license.html).
 
 {% include feature.html content="Workflows are configured in a human-readable
-text format (with programmatic templating)- so you can use software development
-power tools for suite development." %}
+text format, with programmatic templating - so you can use software development
+power tools for workflow development." %}
 
 {% include feature.html content="Scheduling is configured with an efficient
 cycling graph notation, and task runtime properties with an efficient
@@ -36,8 +36,7 @@ inheritance hierarchy." %}
 
 {% include feature.html content="Cylc respects inter-cycle dependence and
 is not constrained by a traditional global cycle loop, so cycles can interleave
-naturally for fast scheduling after delays, and for "off the clock" operation."
-%}
+naturally for fast scheduling after delays, and for 'off the clock' operation." %}
 
 {% include feature.html content="Cylc has low admin overhead and a small
 security footprint, because there is no central server process to manage
@@ -48,7 +47,7 @@ features</a> to support both clock-triggered real time and free-flow
 scheduling in research and operational environments." %}
 
 If you use Cylc to automate your workflows, [please cite Cylc in your
-publications](documentation.html#publications-citations-and-references).
+publications](./documentation.html#publications-citations-and-references).
 
 [Let us know](mailto:hilary.oliver@niwa.co.nz) if your organization
 should be listed on this site with [Cylc Users](./users.html).


### PR DESCRIPTION
Close #34

- two download buttons that clearly indicate "production" or "preview" use
- (removes the automatically updating list of multiple latest releases ... it was kind of cool, but used up screen real estate and no one really needs it).
- (also gratitiously tidied some front page text a bit)

Thought I'd better get this done before going home, in the interests of minimizing user confusion, since @sadielbartholomew raised #30 .

@kinow - my JS may be a bit ropey, but it seems to work https://hjoliver.github.io/cylc.github.io/

One review should do.