### PR TITLE
Show active menu item

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -53,6 +53,20 @@ sass:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
+
+menu:
+  - text: Home
+    url: '/'
+  - text: Docs
+    url: '/documentation'
+  - text: Sites
+    url: '/community'
+  - text: Support
+    url: '/support'
+  - text: Development
+    url: '/development'
+  - text: News
+    url: '/news'
 
 include: [
   "_downloads",

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,15 @@
-{%- assign default_paths = site.pages | map: "path" -%}
-{%- assign page_paths = site.header_pages | default: default_paths -%}
+{%- comment -%}
+This is the page header, and contains the Cylc logo, and menu.
 
+The menu entries are located in the _config.yml file, in the
+project root.
+
+If you want to add a new menu entry, or modify an existing one,
+change that file and either test locally or in your fork.
+
+The checkbox input elements are used for responsive menu, do
+not remove unless you know what you are doing.
+{%- endcomment -%}
 <header class="flex grow shrink header" role="banner">
   <div class="container jc-space-between header-collapse">
       <div class="flex grow shrink site">
@@ -23,50 +32,12 @@
           </div>
 
           <input type="checkbox" id="toggle-checkbox">
-          <div class="links">
-							<div class="link">
-									<a class="page-link" href="{{ '/' | relative_url }}">(Home)</a>
-							</div>
-							<div class="link">
-									<a class="page-link" href="{{ '/documentation' | relative_url }}">Docs</a>
-							</div>
-							<div class="link">
-									<a class="page-link" href="{{ '/community' | relative_url }}">Sites</a>
-							</div>
-							<div class="link">
-									<a class="page-link" href="{{ '/support' | relative_url }}">Support</a>
-							</div>
-							<div class="link">
-									<a class="page-link" href="{{ '/development' | relative_url }}">Development</a>
-							</div>
-							<div class="link">
-									<a class="page-link" href="{{ '/news' | relative_url }}">News</a>
-							</div>
-          </div>
+          {%- include links.html -%}
         </div>
       </div>
 
     <div class="links">
-				<div class="links">
-						<div class="link">
-								<a class="page-link" href="{{ '/' | relative_url }}">(Home)</a>
-						</div>
-						<div class="link">
-								<a class="page-link" href="{{ '/documentation' | relative_url }}">Docs</a>
-						</div>
-						<div class="link">
-								<a class="page-link" href="{{ '/community' | relative_url }}">Sites</a>
-						</div>
-						<div class="link">
-								<a class="page-link" href="{{ '/support' | relative_url }}">Support</a>
-						</div>
-						<div class="link">
-								<a class="page-link" href="{{ '/development' | relative_url }}">Development</a>
-						</div>
-						<div class="link">
-								<a class="page-link" href="{{ '/news' | relative_url }}">News</a>
-						</div>
-				</div>
+      {%- include links.html -%}
     </div>
   </div>
 </header>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,0 +1,7 @@
+<div class="links">
+  {%- for entry in site.menu -%}
+  <div class="link">
+    <a class="page-link" href="{{ entry.url | relative_url }}">{{ entry.text }}</a>
+  </div>
+  {%- endfor -%}
+</div>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,7 +1,24 @@
+{%- comment -%}
+Here are simply create the HTML elements with the list of links.
+
+For each link, we test whether any of `/value`, or `/value/`, or `/value.html`
+matches the current page.url. If so, we add a CSS class to tell that that
+menu entry that matched is the active menu item.
+
+Does not work with multi-level page at the moment, but it would not be too
+hard to add that later as an improvement - if necessary.
+{%- endcomment -%}
 <div class="links">
   {%- for entry in site.menu -%}
-  <div class="link">
-    <a class="page-link" href="{{ entry.url | relative_url }}">{{ entry.text }}</a>
-  </div>
+    {%- assign css_class = "page-link" -%}
+    {%- assign entry_url = entry.url | relative_url -%}
+    {%- assign entry_url_slash = entry.url | relative_url | append: '/' -%}
+    {%- assign entry_url_html = entry.url | relative_url | append: '.html' -%}
+    {%- if entry_url == page.url or entry_url_slash == page.url or entry_url_html == page.url -%}
+      {%- assign css_class = css_class | append: ' active' -%}
+    {%- endif -%}
+    <div class="link">
+      <a class="{{ css_class }}" href="{{ entry.url | relative_url }}">{{ entry.text }}</a>
+    </div>
   {%- endfor -%}
 </div>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -9,12 +9,13 @@ Does not work with multi-level page at the moment, but it would not be too
 hard to add that later as an improvement - if necessary.
 {%- endcomment -%}
 <div class="links">
+  {%- assign page_url = page.url | relative_url -%}
   {%- for entry in site.menu -%}
     {%- assign css_class = "page-link" -%}
     {%- assign entry_url = entry.url | relative_url -%}
     {%- assign entry_url_slash = entry.url | relative_url | append: '/' -%}
     {%- assign entry_url_html = entry.url | relative_url | append: '.html' -%}
-    {%- if entry_url == page.url or entry_url_slash == page.url or entry_url_html == page.url -%}
+    {%- if entry_url == page_url or entry_url_slash == page_url or entry_url_html == page_url-%}
       {%- assign css_class = css_class | append: ' active' -%}
     {%- endif -%}
     <div class="link">

--- a/_sass/cylc/_header.scss
+++ b/_sass/cylc/_header.scss
@@ -44,6 +44,10 @@
       a {
         @extend .flex;
         align-items: center;
+        &.active {
+          font-weight: bold;
+          text-decoration: underline;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #43

Preview: https://kinow.github.io/cylc.github.io/development

Doesn't support multi-level menu hierarchy (i.e. say you browse `/support`, and then there is sub-link to `/support/premium`). In that case, the menu won't show anything as active. That could be improved later if necessary, but I don't think we have a multi-level hierarchy at the moment.

Added notes/comments too for when somebody needs to change the files.

Cheers