### PR TITLE
migrate documentation to cylc-doc

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+  </head>
+  <body
+    style="
+      margin: 0;
+      font-family: sans-serif;
+    "
+  >
+    <div
+      style="
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      "
+    >
+      <div
+        style="
+          text-align: center;
+        "
+      >
+        <img
+         src="/img/cylc-logo.svg"
+        />
+        <h1
+          id="redirect-notice"
+        >
+          404 - Page Not Found
+        </h1>
+        <a
+          id="redirect"
+          href="http://www.cylc.org"
+          style="
+            font-size: 30px;
+            text-decoration: none;
+            border-radius: 10px;
+            background-color: rgb(78,179,247);
+            padding: 10px;
+            color: white;
+          "
+        >
+          Home
+        </a>
+      </div>
+    </div>
+    <script type="text/javascript">
+      // the new path to the default version & format of the docs
+      const newDocRoot = ['cylc-doc', 'current', 'html']
+
+      function compareArrays(a1, a2) {
+        if (a1.length != a2.length) {
+          return false;
+        }
+        return a1.every(function(val, ind) {
+          return val === a2[ind];
+        });
+      }
+
+      function getRedirect() {
+        const parts = window.location.pathname.split('/');
+        if (compareArrays(parts, ['', 'documentation', ''])) {
+          // the old documentation landing page
+          return newDocRoot;
+        }
+        if (compareArrays(parts.slice(0, 3), ['', 'cylc.github.io', 'doc'])) {
+          // the old documentation root dir
+          return newDocRoot.concat(parts.slice(4));
+        }
+        return false;
+      }
+
+      const redirect = getRedirect();
+      if (redirect) {
+        // get the redirect url
+        var url = '/' + redirect.join('/');
+        // add the url fragment if present
+        if (window.location.hash) {
+          url = url + window.location.hash;
+        }
+        // change the redirect notice
+        document.getElementById('redirect-notice')
+          .innerText = 'Page Moved';
+        document.getElementById('redirect')
+          .href = url;
+        document.getElementById('redirect')
+          .innerText = url;
+      }
+    </script>
+  </body>
+</html>

--- a/404.html
+++ b/404.html
@@ -47,7 +47,7 @@
     </div>
     <script type="text/javascript">
       // the new path to the default version & format of the docs
-      const newDocRoot = ['cylc-doc', 'current', 'html']
+      const newDocRoot = ['cylc-doc', 'stable', 'html']
 
       function compareArrays(a1, a2) {
         if (a1.length != a2.length) {

--- a/_config.yml
+++ b/_config.yml
@@ -63,6 +63,8 @@ menu:
     url: '/community'
   - text: Support
     url: '/support'
+  - text: FAQ
+    url: '/faq'
   - text: Development
     url: '/development'
   - text: News

--- a/_config.yml
+++ b/_config.yml
@@ -58,7 +58,7 @@ menu:
   - text: Home
     url: '/'
   - text: Docs
-    url: '/documentation'
+    url: '/cylc-doc/index.html'
   - text: Sites
     url: '/community'
   - text: Support

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -289,13 +289,72 @@
 
 		<div class="flex">
         <div class="container flex--vertical">
-
+            <h3>Publications</h3>
 						<p><b>If you use Cylc</b> please <a
 								href="documentation#publications">cite it in your
 								publications</a> and <a href="community#user-support">let us
 						know</a> if your organization should be <a
 				href="community#sites-using-cylc">listed on this website</a>.
 						</p>
+
+            <p>
+              <b>
+                Workflow Automation for Cycling Systems: The
+                Cylc Workflow Engine
+              </b>
+              <br />
+              H. Oliver et al
+              <br />
+              <em>
+                Computing in Science & Engineering Vol
+                21, Issue 4, July/Aug 2019. DOI: 10.1109/MCSE.2019.2906593
+              </em>
+              <br />
+              <a
+               href="https://doi.org/10.1109/MCSE.2019.2906593"
+              >
+                DOI: 10.1109/MCSE.2019.2906593
+              </a>
+            </p>
+
+            <p>
+              <b>
+                Cylc: A Workflow Engine for Cycling Systems
+              </b>
+              <br />
+              Oliver et al., (2018).
+              <br />
+              <em>
+                Journal of Open Source Software, 3(27), 737.
+                DOI: 10.21105/joss.00737
+              </em>
+              <br />
+              <a
+               href="https://doi.org/10.21105/joss.00737"
+              >
+                <img
+                 src="http://joss.theoj.org/papers/10.21105/joss.00737/status.svg"
+                />
+              </a>
+              <br />
+            </p>
+
+            <p>
+              <b>
+                Citable DOI for Cylc code releases.
+              </b>
+              <br />
+              <a
+               href="https://zenodo.org/badge/latestdoi/1836229"
+              >
+                <img
+                 src="https://zenodo.org/badge/1836229.svg"
+                />
+              </a>
+            </p>
+        </div>
+
+        <div class="container flex--vertical">
         </div>
       </div>
 

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,46 @@
+---
+layout: home
+title: Frequently Asked Questions
+---
+
+# Frequently Asked Questions
+
+(This FAQ is still new and will be added to in time).
+
+## What are the major capabilities and features of Cylc?
+
+See the [front page of this website]({{'/' | relative_url}})
+
+## Does Cylc automatically manage task data?
+
+No. For maximum flexibility and generality, Cylc is a pure orchestration engine
+that manages task execution according to *abstract dependencies*. It is left to
+the workflow designer to make sure that the tasks use shared data areas or move
+data around as needed, by whatever means is appropriate to your data types and
+platforms. (Cylc does provide easy access to a self-contained shared data area
+for each workflow). This is easy to do, and it avoids the risk of restrictive
+assumptions or unnecessary data movement.
+
+We do note however that there are good use cases for a "data modeling" approach
+whereby the workflow structure self-assembles from explicit *data
+dependencies*, and the workflow engine may automatically manage the data too.
+Cylc actually uses a self-assembling workflow model internally, and we are
+considering exposing this again as an option in the future.
+
+## Does Cylc have built-in Cloud and Container "integration"?
+
+No, because our historical home base is production weather forecasting, and
+related systems, which is still almost entirely done on in-house HPC systems.
+Cloud and containers are definitely coming soon to this world too, but for the
+moment you'll have to "roll your own" use of Cylc with them. That is easy
+enough to do though because Cylc runs on any Linux VM and the jobs that it
+manages can do anything you want.
+
+## Does Cylc support the Common Workflow Language?
+
+No, Cylc doesn't support CWL at this stage because CWL does not understand
+cycling workflows (see for example the eWaterCycle Case Study in the [Cylc
+CiSE paper](#publications)).
+
+
+


### PR DESCRIPTION
**Note Don't Merge**
*I'm thinking we should merge this after 8.0a3 release so we get time to test the release mechanism on the offline docs.*

* Removes the documentation from this site, linking it to the cylc-doc gh-pages.
* Adds a 404 page which uses Javascript to redirect present users with a redirect notice with a link to the new docs.
* Migrates the publication section from `documentation.md` to the homepage.
* Migrates the FAQ to its own page.
* Deletes the screenshot page (we may want to restore, but where to).

> **Note:** Pre merge the default documentation version should changed to 7.9.x on the cylc-doc gh-pages branch
>
> **Done**