### PR TITLE
Fix 404 image location

### DIFF
--- a/404.html
+++ b/404.html
@@ -22,7 +22,7 @@
         "
       >
         <img
-         src="/img/cylc-logo.svg"
+         src="/assets/img/cylc-logo.svg"
         />
         <h1
           id="redirect-notice"


### PR DESCRIPTION
Broken image at the moment: https://cylc.github.io/doc/built-sphinx/workflow-design-guide/workflow-design-guide-master.html

It's trying to open https://cylc.github.io/img/cylc-logo.svg, while it should be https://cylc.github.io/assets/img/cylc-logo.svg