### PR TITLE
Add jekyll redirect from

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "jekyll", "~> 4.0.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 gem 'jekyll-sass-converter', git: 'https://github.com/jekyll/jekyll-sass-converter', branch: 'master'
+gem 'jekyll-redirect-from'
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       terminal-table (~> 1.8)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
@@ -83,8 +85,12 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   jekyll-sass-converter!
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+
+BUNDLED WITH
+   2.2.11

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ url: "https://cylc.github.io" # the base hostname & protocol for your site, e.g.
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 sass:
   style: compressed

--- a/index.md
+++ b/index.md
@@ -1,4 +1,6 @@
 ---
 layout: default
 title: Cylc
+redirect_from:
+  - /cylc
 ...


### PR DESCRIPTION
Closes #55 

Tested locally and it worked with no issues. The gem used is supported by [github pages](https://pages.github.com/versions/). Testing now in GH pages on my fork.