### PR TITLE
fix docs redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -64,9 +64,16 @@
           // the old documentation landing page
           return newDocRoot;
         }
-        if (compareArrays(parts.slice(0, 3), ['', 'cylc.github.io', 'doc'])) {
+        if (
+          compareArrays(parts.slice(0, 3), ['', 'cylc.github.io', 'doc'])
+          || compareArrays(parts.slice(0, 3), ['', 'doc', 'built-sphinx'])
+        ) {
           // the old documentation root dir
           return newDocRoot.concat(parts.slice(4));
+        }
+        if (compareArrays(parts.slice(0, 2), ['', 'doc'])) {
+          // the old documentation landing page
+          return newDocRoot.concat(parts.slice(3));
         }
         return false;
       }


### PR DESCRIPTION
Should allow redirects from the old `doc` landing page (document now removed) and the old `build-sphinx` redirect.

Test by visiting `https://cylc.github.io/doc/built-sphinx` and checking the `window.location.pathname`:

```
>>> window.location.pathname.split('/')
Array(3) [ "", "doc", "built-sphinx" ]
```